### PR TITLE
Rendered Jinja params for system props in control implementation statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 GovReady-Q Release Notes
 ========================
 
+v0.xx.xx (December 10, 2023)
+---------------------------
+
+**Feature changes**
+
+* Support dynamically rendered Jinja parameters for system properties in control implementation statements.
+
+**UI changes**
+
+* Display rendered parameters for system properties in system control implementation statements.
+
+**Developer changes**
+
+* Add statement.body_rendered property containing jinja rendered content in system control implementation statements.
+
 v0.11.8 (June 11, 2023)
 ---------------------------
 
@@ -24,9 +39,6 @@ v0.11.6 (March 14, 2023)
 **Developer changes**
 
 * Upgrade Python libraries.
-
-**Developer changes**
-
 * Add siteapp.management_views as webhooks for calling Django management commands.
 
 

--- a/controls/models.py
+++ b/controls/models.py
@@ -882,13 +882,16 @@ class System(auto_prefetch.Model, TagModelMixin, ProposalModelMixin):
             #     print(f"self.pid_current: {self.pid_current} XXXXXXXXXXXXX") # DEBUG
             #     self.pid_current = smt.pid
             if smt.producer_element:
+                #smt_formatted = smt.body.replace('\n','<br/>')
                 # Add 'body_rendered' property to smt containing rendered version of smt.body in case we have embedded parameters
-                # System is available here as self
+                # System is available here as `self`
                 smt_env = Environment(loader=DictLoader({'smt_body_template': smt.body}))
                 template = smt_env.get_template('smt_body_template')
-                smt.body_rendered = template.render(system=self)
+                try:
+                    smt.body_rendered = template.render(system=self)
+                except:
+                    smt.body_rendered = "<ERROR: incorrect jinja variable>\n" + smt.body
                 smt_formatted = smt.body_rendered.replace('\n','<br/>')
-                # smt_formatted = smt.body.replace('\n','<br/>')
                 # TODO: Clean up special characters
                 smt_formatted = smt_formatted.replace(u"\u2019", "'").replace(u"\u2022", "<li>")
                 # Poor performance, at least in some instances, appears to being caused by `smt.producer_element.name`
@@ -1017,6 +1020,16 @@ class System(auto_prefetch.Model, TagModelMixin, ProposalModelMixin):
         )
 
         return se
+
+    def answer(self, module='speedy_ssp_basic_info',answer='internal_customer'):
+        # To Do:
+        try:
+            module_question_answer = self.projects.all()[0].export_json()['project']['answers'][module]['value']['answers'][answer]['text']
+            return module_question_answer
+        except:
+            return f"<missing param: {module} or {answer}>"
+
+
 
 class SystemEvent(auto_prefetch.Model, TagModelMixin, BaseModel):
     system = auto_prefetch.ForeignKey('System', related_name='events', on_delete=models.CASCADE, blank=True,

--- a/controls/models.py
+++ b/controls/models.py
@@ -30,6 +30,7 @@ from copy import deepcopy
 from django.db import transaction
 from django.core.validators import RegexValidator
 from django.core.validators import validate_email
+from jinja2 import Environment, DictLoader
 
 import structlog
 from structlog import get_logger
@@ -881,7 +882,13 @@ class System(auto_prefetch.Model, TagModelMixin, ProposalModelMixin):
             #     print(f"self.pid_current: {self.pid_current} XXXXXXXXXXXXX") # DEBUG
             #     self.pid_current = smt.pid
             if smt.producer_element:
-                smt_formatted = smt.body.replace('\n','<br/>')
+                # Add 'body_rendered' property to smt containing rendered version of smt.body in case we have embedded parameters
+                # System is available here as self
+                smt_env = Environment(loader=DictLoader({'smt_body_template': smt.body}))
+                template = smt_env.get_template('smt_body_template')
+                smt.body_rendered = template.render(system=self)
+                smt_formatted = smt.body_rendered.replace('\n','<br/>')
+                # smt_formatted = smt.body.replace('\n','<br/>')
                 # TODO: Clean up special characters
                 smt_formatted = smt_formatted.replace(u"\u2019", "'").replace(u"\u2022", "<li>")
                 # Poor performance, at least in some instances, appears to being caused by `smt.producer_element.name`

--- a/controls/views.py
+++ b/controls/views.py
@@ -2293,7 +2293,10 @@ def editor(request, system_id, catalog_key, cl_id):
         for smt in impl_smts:
             smt_env = Environment(loader=DictLoader({'smt_body_template': smt.body}))
             template = smt_env.get_template('smt_body_template')
-            smt.body_rendered = template.render(system=system)
+            try:
+                smt.body_rendered = template.render(system=system)
+            except:
+                smt.body_rendered = "<ERROR: incorrect jinja variable>\n" + smt.body
             #rendered = template.render(project=project, system=system)
 
         # oscalize key

--- a/controls/views.py
+++ b/controls/views.py
@@ -26,6 +26,7 @@ from django.db.models import Q
 from django.db.models.functions import Lower
 from django.http import Http404, HttpResponse, HttpResponseRedirect, HttpResponseForbidden, JsonResponse, \
     HttpResponseNotAllowed
+from jinja2 import Environment, DictLoader
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.text import slugify
@@ -2285,6 +2286,16 @@ def editor(request, system_id, catalog_key, cl_id):
         # need parties and roles to not be empty
         # Build OSCAL SSP
         # Example: https://github.com/usnistgov/oscal-content/tree/master/examples/ssp/json/ssp-example.json
+
+        # Add 'body_rendered' property to smt containing rendered version of smt.body in case we have embedded parameters
+        # Get the system
+        system = System.objects.get(pk=system_id)
+        for smt in impl_smts:
+            smt_env = Environment(loader=DictLoader({'smt_body_template': smt.body}))
+            template = smt_env.get_template('smt_body_template')
+            smt.body_rendered = template.render(system=system)
+            #rendered = template.render(project=project, system=system)
+
         # oscalize key
         cl_id = oscalize_control_id(cl_id)
 

--- a/siteapp/urls.py
+++ b/siteapp/urls.py
@@ -104,7 +104,7 @@ urlpatterns = [
     url(r"^systems/", include("controls.urls")),
     url(r"^api/v1/systems/", include("controls.urls_api")),
 
-    url(r"^controls$", include("controls.urls")),
+    # url(r"^controls$", include("controls.urls")),
     url(r"^controls/", include("controls.urls")),
 
     # portfolios

--- a/templates/controls/editor.html
+++ b/templates/controls/editor.html
@@ -305,7 +305,7 @@
                                             <span class="component-state">{{ smt.producer_element.component_state }}</span>
                                         </div>
                                       </div>
-                                      <div class="col-xs-6 col-sm-6 col-md-6 col-lg-6 col-xl-6 statement-text-block">{% if smt.pid is not None and smt.pid != "" %}<div class="panel-heading-smt">{{ smt.pid }}.</div>{% endif %}{{ smt.body }}</div>
+                                      <div class="col-xs-6 col-sm-6 col-md-6 col-lg-6 col-xl-6 statement-text-block">{% if smt.pid is not None and smt.pid != "" %}<div class="panel-heading-smt">{{ smt.pid }}.</div>{% endif %}{{ smt.body_rendered }}</div>
                                       <div class="col-xs-3 col-sm-3 col-md-3 col-lg-3 col-xl-3 remark-text-block">
                                         {% spaceless %}
                                         <span>Status: {% if smt.status != "" and smt.status is not None %}{{ smt.status }}{% else %}TBD{% endif %}</span>


### PR DESCRIPTION
This PR adds support for Jinja parameter substitution in component control implementations. The support is currently only for `system` object parameters.

Purpose is to be able to include the System Title (and other system-specific information) within a control implementation statement that rendered in the System Security Plan.

Change accomplished by selectively adding a `statement.body_rendered` property. The `body_rendered` property is added in two places:

1. when rendering the read-only system control implementation statements that are displayed for system controls,
2. when rendering the Statement's `control_implementation_as_dict`'s combined statement that is used to display the control implementation statements in the System Security Plan output templates.

This approach nicely allows components to contain the Jinja parameter double brace template parameters (e.g., `{{ system.root_element.title }}`).

Todo:
- [ ] check if rendering is working system component control implementation statements

## Screenshots

### in the System control implementations statements
<img width="1840" alt="image" src="https://github.com/wbnod/govready-q/assets/24979/c77cc353-522e-4c5f-8ead-cb90e3e31e46">

### in the System control implementation statement editing, the Jinja double brace parameter still appears
<img width="1840" alt="image" src="https://github.com/wbnod/govready-q/assets/24979/5ad48372-8cc4-4a89-bf1d-d51d838723de">


### In the rendered SSP
<img width="751" alt="image" src="https://github.com/wbnod/govready-q/assets/24979/ea012210-665a-4114-a0ea-61f6c0a3597a">
